### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/TinyBMP280/keywords.txt
+++ b/TinyBMP280/keywords.txt
@@ -7,16 +7,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-TinyBMP280  KEYWORD1
+TinyBMP280	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin   KEYWORD2
-readTemperature    KEYWORD2
-readPressure    KEYWORD2
-readAltitude    KEYWORD2
+begin	KEYWORD2
+readTemperature	KEYWORD2
+readPressure	KEYWORD2
+readAltitude	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords